### PR TITLE
fix SRC_URI with experimental flag

### DIFF
--- a/profiles/funtoo/1.0/platform/linux-gnu/packages.build
+++ b/profiles/funtoo/1.0/platform/linux-gnu/packages.build
@@ -1,0 +1,1 @@
+../../../../default/linux/packages.build


### PR DESCRIPTION
Sorry for not testing this properly.

This commit makes sure that both the master and funtoo-path distfiles are used when running ebuild digest.

Additionally you will have tag each commit in funtoo-path that merges master.

The Manifest has not been updated as such a tag does not exist yet.

Also see: http://forums.funtoo.org/viewtopic.php?pid=1717#p1717

Turned out this hack was even uglier than expected...
