### PR TITLE
Version Bump: app-admin-salt

### DIFF
--- a/app-admin/salt/salt-0.14.1.ebuild
+++ b/app-admin/salt/salt-0.14.1.ebuild
@@ -8,7 +8,7 @@ inherit distutils eutils
 
 DESCRIPTION="Salt is a remote execution and configuration manager."
 HOMEPAGE="http://saltstack.org/"
-SRC_URI="mirror://github/saltstack/${PN}/${P}.tar.gz"
+SRC_URI="http://pypi.python.org/packages/source/s/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"


### PR DESCRIPTION
Bumping version of app-admin/salt (Saltstack) to 0.14.1 (http://salt.readthedocs.org/en/latest/topics/releases/0.14.0.html) and testing the new community-driven approach. :)
