### PR TITLE
fix grub-legacy-static dependency

### DIFF
--- a/sys-boot/grub-legacy-static/grub-legacy-static-0.97-r9.ebuild
+++ b/sys-boot/grub-legacy-static/grub-legacy-static-0.97-r9.ebuild
@@ -21,7 +21,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
 IUSE=""
-DEPEND="!sys-boot/grub"
+DEPEND="!sys-boot/grub-legacy"
 PROVIDE="virtual/bootloader"
 
 pkg_setup() {


### PR DESCRIPTION
sys-boot/grub is GRUB2!
grub1 is sys-boot/grub-LEGACY!
