### PR TITLE
Set libwnck-2.30.7 as a fixed depency For emerald

### DIFF
--- a/x11-wm/emerald/emerald-0.9.5.ebuild
+++ b/x11-wm/emerald/emerald-0.9.5.ebuild
@@ -18,7 +18,7 @@ PDEPEND="~x11-themes/emerald-themes-${THEMES_RELEASE}"
 
 RDEPEND=" 
 	>=x11-libs/gtk+-2.8.0:2 
-	>=x11-libs/libwnck-2.30.7 
+	 =x11-libs/libwnck-2.31.0
 	>=x11-wm/compiz-${PV} 
 "
 


### PR DESCRIPTION
Newer package versions of libwnck do not include  libwnck-1.so, a fixed depency of emerald.
libwnck-2.31.0 is the last built package in the gentoo and funtoo distro that contains libwnck.