### PR TITLE
FL-2225: llvm 3.6 jitmemorymanager patch

### DIFF
--- a/media-libs/mesa/files/mesa-10.4-llvm-3.6-jitmemorymanager.patch
+++ b/media-libs/mesa/files/mesa-10.4-llvm-3.6-jitmemorymanager.patch
@@ -1,0 +1,25 @@
+As of r223183 EngineBuilder::setMCJITMemoryManager() takes a unique_ptr.
+---
+ src/gallium/auxiliary/gallivm/lp_bld_misc.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+index fe3c754..5c01f53 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+@@ -500,8 +500,13 @@ lp_build_create_jit_compiler_for_module(LLVMExecutionEngineRef *OutJIT,
+        MM = new ShaderMemoryManager(JMM);
+        *OutCode = MM->getGeneratedCode();
+ 
++#if HAVE_LLVM >=0x0306
++       builder.setMCJITMemoryManager(std::unique_ptr<ShaderMemoryManager>(MM));
++#else
+        builder.setMCJITMemoryManager(MM);
+ #endif
++
++#endif
+    } else {
+ #if HAVE_LLVM < 0x0306
+        BaseMemoryManager* JMM = reinterpret_cast<BaseMemoryManager*>(CMM);
+--
+1.8.5.5

--- a/media-libs/mesa/mesa-10.4.4.ebuild
+++ b/media-libs/mesa/mesa-10.4.4.ebuild
@@ -217,6 +217,9 @@ src_prepare() {
 	# fix for hardened pax_kernel, bug 240956
 	[[ ${PV} != 9999* ]] && epatch "${FILESDIR}"/glx_ro_text_segm.patch
 
+	# fix for llvm >= 3.6 (FL-2225)
+	[[ ${PV} != 9999* ]] && epatch "${FILESDIR}"/mesa-10.4-llvm-3.6-jitmemorymanager.patch
+
 	# Solaris needs some recent POSIX stuff in our case
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		sed -i -e "s/-DSVR4/-D_POSIX_C_SOURCE=200112L/" configure.ac || die


### PR DESCRIPTION
Applied patch for https://bugs.funtoo.org/browse/FL-2225